### PR TITLE
Changed the name of the method uses: for resolvesUsing: to be more declarative

### DIFF
--- a/repository/IngSoft2-Model/AccelerationCard.class.st
+++ b/repository/IngSoft2-Model/AccelerationCard.class.st
@@ -17,7 +17,7 @@ AccelerationCard >> effect [
 ]
 
 { #category : #delegating }
-AccelerationCard >> uses: cardPlayResolver [
+AccelerationCard >> resolvesUsing: cardPlayResolver [
 
 	cardPlayResolver resolveAnAccelerationCardPlay: self
 ]

--- a/repository/IngSoft2-Model/AllyCard.class.st
+++ b/repository/IngSoft2-Model/AllyCard.class.st
@@ -11,7 +11,7 @@ AllyCard >> cancelEffectUsing: cardPlayResolver [
 ]
 
 { #category : #delegating }
-AllyCard >> uses: cardPlayResolver [
+AllyCard >> resolvesUsing: cardPlayResolver [
 
 	cardPlayResolver resolveAnAllyCardPlay: self
 ]

--- a/repository/IngSoft2-Model/CancellationCard.class.st
+++ b/repository/IngSoft2-Model/CancellationCard.class.st
@@ -5,7 +5,7 @@ Class {
 }
 
 { #category : #delegating }
-CancellationCard >> uses: cardPlayResolver [
+CancellationCard >> resolvesUsing: cardPlayResolver [
 
 	cardPlayResolver resolveACancellationCardPlay: self
 ]

--- a/repository/IngSoft2-Model/Card.class.st
+++ b/repository/IngSoft2-Model/Card.class.st
@@ -5,7 +5,7 @@ Class {
 }
 
 { #category : #delegating }
-Card >> uses: cardPlayResolver [
+Card >> resolvesUsing: cardPlayResolver [
 
 	self subclassResponsibility
 ]

--- a/repository/IngSoft2-Model/CardPlayResolver.class.st
+++ b/repository/IngSoft2-Model/CardPlayResolver.class.st
@@ -58,7 +58,7 @@ CardPlayResolver >> resolve: aCardPlayed by: aSpaceship targetting: anotherSpace
 
 	cardUser := aSpaceship.
 	cardTarget := anotherSpaceship.
-	aCardPlayed uses: self
+	aCardPlayed resolvesUsing: self
 ]
 
 { #category : #resolving }

--- a/repository/IngSoft2-Model/LeakCard.class.st
+++ b/repository/IngSoft2-Model/LeakCard.class.st
@@ -11,7 +11,7 @@ LeakCard >> cancelEffectUsing: cardPlayResolver [
 ]
 
 { #category : #delegating }
-LeakCard >> uses: cardPlayResolver [
+LeakCard >> resolvesUsing: cardPlayResolver [
 
 	cardPlayResolver resolveALeakCardPlay: self
 ]

--- a/repository/IngSoft2-Model/NitroCard.class.st
+++ b/repository/IngSoft2-Model/NitroCard.class.st
@@ -11,7 +11,7 @@ NitroCard >> effect [
 ]
 
 { #category : #delegating }
-NitroCard >> uses: cardPlayResolver [
+NitroCard >> resolvesUsing: cardPlayResolver [
 
 	cardPlayResolver resolveANitroCardPlay: self
 ]

--- a/repository/IngSoft2-Model/OverloadCard.class.st
+++ b/repository/IngSoft2-Model/OverloadCard.class.st
@@ -17,7 +17,7 @@ OverloadCard >> effect [
 ]
 
 { #category : #delegating }
-OverloadCard >> uses: cardPlayResolver [
+OverloadCard >> resolvesUsing: cardPlayResolver [
 
 	cardPlayResolver resolveAnOverloadCardPlay: self
 ]

--- a/repository/IngSoft2-Model/ProbabilityElement.class.st
+++ b/repository/IngSoft2-Model/ProbabilityElement.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #ProbabilityAssigner,
+	#name : #ProbabilityElement,
 	#superclass : #Object,
 	#instVars : [
 		'element',
@@ -9,14 +9,14 @@ Class {
 }
 
 { #category : #asserting }
-ProbabilityAssigner class >> assertIsBetweenZeroAndOne: probability [
+ProbabilityElement class >> assertIsBetweenZeroAndOne: probability [
 
 	(probability between: 0 and: 1) ifFalse: [
 		Error signal: 'Probability must be between 0 and 1!' ]
 ]
 
 { #category : #'instance creation' }
-ProbabilityAssigner class >> with: element and: probability [
+ProbabilityElement class >> with: element and: probability [
 
 	self assertIsBetweenZeroAndOne: probability.
 
@@ -24,20 +24,20 @@ ProbabilityAssigner class >> with: element and: probability [
 ]
 
 { #category : #accessing }
-ProbabilityAssigner >> element [
+ProbabilityElement >> element [
 
 	^ element
 ]
 
 { #category : #initialization }
-ProbabilityAssigner >> initializeWith: anElement and: aProbability [
+ProbabilityElement >> initializeWith: anElement and: aProbability [
 
 	element := anElement.
 	probability := aProbability
 ]
 
 { #category : #accessing }
-ProbabilityAssigner >> probability [
+ProbabilityElement >> probability [
 
 	^ probability
 ]

--- a/repository/IngSoft2-Model/RedoCard.class.st
+++ b/repository/IngSoft2-Model/RedoCard.class.st
@@ -5,7 +5,7 @@ Class {
 }
 
 { #category : #delegating }
-RedoCard >> uses: cardPlayResolver [
+RedoCard >> resolvesUsing: cardPlayResolver [
 
 	cardPlayResolver resolveARedoCardPlay: self
 ]

--- a/repository/IngSoft2-Model/RepeatCard.class.st
+++ b/repository/IngSoft2-Model/RepeatCard.class.st
@@ -5,7 +5,7 @@ Class {
 }
 
 { #category : #delegating }
-RepeatCard >> uses: cardPlayResolver [
+RepeatCard >> resolvesUsing: cardPlayResolver [
 
 	cardPlayResolver resolveARepeatCardPlay: self
 ]

--- a/repository/IngSoft2-Tests/DistributionTest.class.st
+++ b/repository/IngSoft2-Tests/DistributionTest.class.st
@@ -21,25 +21,25 @@ DistributionTest >> testEffectDistributionSumOfProbabilitiesMustBeEqualToOne [
 	self
 		should: [
 			effectDistribution := Distribution with: {
-					                      (ProbabilityAssigner
+					                      (ProbabilityElement
 						                       with: Null new
 						                       and: 0.30).
-					                      (ProbabilityAssigner
+					                      (ProbabilityElement
 						                       with: BlackHole new
 						                       and: 0.20).
-					                      (ProbabilityAssigner
+					                      (ProbabilityElement
 						                       with: (HyperGravity needsToThrow: 3)
 						                       and: 0.20).
-					                      (ProbabilityAssigner
+					                      (ProbabilityElement
 						                       with: (MoonWalk backwardDistance: 3)
 						                       and: 0.10).
-					                      (ProbabilityAssigner
+					                      (ProbabilityElement
 						                       with: CardGiver new
 						                       and: 0.10).
-					                      (ProbabilityAssigner
+					                      (ProbabilityElement
 						                       with: (HyperJump of: { 3. 2. 1 })
 						                       and: 0.08).
-					                      (ProbabilityAssigner
+					                      (ProbabilityElement
 						                       with: AtomicBomb new
 						                       and: 0.03) } ]
 		raise: Error
@@ -50,7 +50,7 @@ DistributionTest >> testEffectDistributionSumOfProbabilitiesMustBeEqualToOne [
 DistributionTest >> testProbabilityEffectProbabilityMustBeBetwenZeroAndOne [
 
 	self
-		should: [ ProbabilityAssigner with: Null new and: 2 ]
+		should: [ ProbabilityElement with: Null new and: 2 ]
 		raise: Error
 		withMessage: 'Probability must be between 0 and 1!'
 ]
@@ -68,25 +68,25 @@ DistributionTest >> testThatAtomicBombEffectHasTwoPercentProbability [
 	cardGiverEffect := CardGiver new.
 
 	effectDistribution := Distribution with: {
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: nullEffect
 				                       and: 0.30).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: cardGiverEffect
 				                       and: 0.10).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: blackHoleEffect
 				                       and: 0.2).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: hyperGravityEffect
 				                       and: 0.2).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: moonWalkEffect
 				                       and: 0.10).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: hyperJumpEffect
 				                       and: 0.08).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: atomicBombEffect
 				                       and: 0.02) }.
 
@@ -108,25 +108,25 @@ DistributionTest >> testThatBlackHoleEffectHasTwentyPercentProbability [
 	cardGiverEffect := CardGiver new.
 
 	effectDistribution := Distribution with: {
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: nullEffect
 				                       and: 0.30).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: cardGiverEffect
 				                       and: 0.10).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: blackHoleEffect
 				                       and: 0.2).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: hyperGravityEffect
 				                       and: 0.2).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: moonWalkEffect
 				                       and: 0.10).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: hyperJumpEffect
 				                       and: 0.08).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: atomicBombEffect
 				                       and: 0.02) }.
 
@@ -148,25 +148,25 @@ DistributionTest >> testThatCardGiverHasTenPercentProbability [
 	cardGiverEffect := CardGiver new.
 
 	effectDistribution := Distribution with: {
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: nullEffect
 				                       and: 0.30).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: cardGiverEffect
 				                       and: 0.10).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: blackHoleEffect
 				                       and: 0.2).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: hyperGravityEffect
 				                       and: 0.2).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: moonWalkEffect
 				                       and: 0.10).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: hyperJumpEffect
 				                       and: 0.08).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: atomicBombEffect
 				                       and: 0.02) }.
 
@@ -188,25 +188,25 @@ DistributionTest >> testThatHyperGravityEffectHasTwentyPercentProbability [
 	cardGiverEffect := CardGiver new.
 
 	effectDistribution := Distribution with: {
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: nullEffect
 				                       and: 0.30).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: cardGiverEffect
 				                       and: 0.10).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: blackHoleEffect
 				                       and: 0.2).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: hyperGravityEffect
 				                       and: 0.2).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: moonWalkEffect
 				                       and: 0.10).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: hyperJumpEffect
 				                       and: 0.08).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: atomicBombEffect
 				                       and: 0.02) }.
 
@@ -228,25 +228,25 @@ DistributionTest >> testThatHyperJumpEffectHasEightPercentProbability [
 	cardGiverEffect := CardGiver new.
 
 	effectDistribution := Distribution with: {
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: nullEffect
 				                       and: 0.30).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: cardGiverEffect
 				                       and: 0.10).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: blackHoleEffect
 				                       and: 0.2).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: hyperGravityEffect
 				                       and: 0.2).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: moonWalkEffect
 				                       and: 0.10).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: hyperJumpEffect
 				                       and: 0.08).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: atomicBombEffect
 				                       and: 0.02) }.
 
@@ -268,25 +268,25 @@ DistributionTest >> testThatMoonWalkEffectHasTenPercentProbability [
 	cardGiverEffect := CardGiver new.
 
 	effectDistribution := Distribution with: {
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: nullEffect
 				                       and: 0.30).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: cardGiverEffect
 				                       and: 0.10).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: blackHoleEffect
 				                       and: 0.2).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: hyperGravityEffect
 				                       and: 0.2).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: moonWalkEffect
 				                       and: 0.10).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: hyperJumpEffect
 				                       and: 0.08).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: atomicBombEffect
 				                       and: 0.02) }.
 
@@ -308,25 +308,25 @@ DistributionTest >> testThatNullEffectHasThirtyPercentProbability [
 	cardGiverEffect := CardGiver new.
 
 	effectDistribution := Distribution with: {
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: nullEffect
 				                       and: 0.30).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: cardGiverEffect
 				                       and: 0.10).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: blackHoleEffect
 				                       and: 0.2).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: hyperGravityEffect
 				                       and: 0.2).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: moonWalkEffect
 				                       and: 0.10).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: hyperJumpEffect
 				                       and: 0.08).
-			                      (ProbabilityAssigner
+			                      (ProbabilityElement
 				                       with: atomicBombEffect
 				                       and: 0.02) }.
 

--- a/repository/IngSoft2-Tests/FourthVersionTest.class.st
+++ b/repository/IngSoft2-Tests/FourthVersionTest.class.st
@@ -24,7 +24,7 @@ FourthVersionTest >> testFV01DeckHasALimitedAmountOfCards [
 	anAccelerationCard := AccelerationCard new.
 
 	cardsDistribution := Distribution with:
-		                     { (ProbabilityAssigner
+		                     { (ProbabilityElement
 			                      with: anAccelerationCard
 			                      and: 1) }.
 
@@ -74,7 +74,7 @@ FourthVersionTest >> testFV02WhenAnInstantCardIsUsedItGoesToTheDiscardDeck [
 	aNitroCard := NitroCard new.
 
 	cardsDistribution := Distribution with:
-		                     { (ProbabilityAssigner with: aNitroCard and: 1) }.
+		                     { (ProbabilityElement with: aNitroCard and: 1) }.
 
 	cardsCollection := cardsDistribution randomCollectionWith: 5.
 
@@ -140,9 +140,9 @@ FourthVersionTest >> testFV03WhenDeckIsEmptyDiscardDeckIsShuffledAndThatIsTheNew
 	aNitroCard := NitroCard new.
 
 	cardsDistribution := Distribution with:
-		                     { (ProbabilityAssigner with: aNitroCard and: 1) }.
+		                     { (ProbabilityElement with: aNitroCard and: 1) }.
 
-	cardsCollection := cardsDistribution randomCollectionWith: 5.
+	cardsCollection := cardsDistribution randomCollectionWith: 6.
 
 	aDeck := Deck of: cardsCollection.
 
@@ -159,24 +159,24 @@ FourthVersionTest >> testFV03WhenDeckIsEmptyDiscardDeckIsShuffledAndThatIsTheNew
 		with: 1
 		in: aGame.
 	self assert: (aGame cardsHandOf: 'Danny') cardsInHand size equals: 2.
-	self assert: aGame deckLength equals: 1.
+	self assert: (aGame cardsHandOf: 'Walter') cardsInHand size equals: 2.
+	self assert: aGame deckLength equals: 2.
 	self assert: aGame discardDecklength equals: 0.
 
 	aGame play: aNitroCard by: 'Danny' targetting: 'Danny'.
+	aGame play: aNitroCard by: 'Walter' targetting: 'Walter'.
 
 	self assert: (aGame cardsHandOf: 'Danny') cardsInHand size equals: 1.
-	self assert: aGame deckLength equals: 1.
-	self assert: aGame discardDecklength equals: 1.
+	self assert: (aGame cardsHandOf: 'Walter') cardsInHand size equals: 1.
+	self assert: aGame deckLength equals: 2.
+	self assert: aGame discardDecklength equals: 2.
 
 	aGame playNextTurn.
+	aGame playNextTurn.
 
-	self
-		assert: 'Danny'
-		isAt: 6
-		with: 1
-		in: aGame.
 	self assert: (aGame cardsHandOf: 'Danny') cardsInHand size equals: 2.
-	self assert: aGame deckLength equals: 1.
+	self assert: (aGame cardsHandOf: 'Walter') cardsInHand size equals: 2.
+	self assert: aGame deckLength equals: 2.
 	self assert: aGame discardDecklength equals: 0
 ]
 
@@ -207,24 +207,24 @@ FourthVersionTest >> testFV04DeckHasProbabilityOfOccurrence [
 	aLeakCard := LeakCard new.
 
 	cardsDistribution := Distribution with: {
-			                     (ProbabilityAssigner
+			                     (ProbabilityElement
 				                      with: anAllyCard
 				                      and: 0.20).
-			                     (ProbabilityAssigner
+			                     (ProbabilityElement
 				                      with: anOverloadCard
 				                      and: 0.20).
-			                     (ProbabilityAssigner
+			                     (ProbabilityElement
 				                      with: aCancellationCard
 				                      and: 0.20).
-			                     (ProbabilityAssigner
+			                     (ProbabilityElement
 				                      with: anAccelerationCard
 				                      and: 0.20).
-			                     (ProbabilityAssigner with: aRedoCard and: 0.10).
-			                     (ProbabilityAssigner with: aRepeatCard and: 0).
-			                     (ProbabilityAssigner
+			                     (ProbabilityElement with: aRedoCard and: 0.10).
+			                     (ProbabilityElement with: aRepeatCard and: 0).
+			                     (ProbabilityElement
 				                      with: aNitroCard
 				                      and: 0.05).
-			                     (ProbabilityAssigner with: aLeakCard and: 0.05) }.
+			                     (ProbabilityElement with: aLeakCard and: 0.05) }.
 
 	cardsCollection := cardsDistribution randomCollectionWith: 20.
 
@@ -286,7 +286,7 @@ FourthVersionTest >> testFV05WhenSpaceshipUsesNitroCardItAddsThreeToTheTotalRoll
 	aNitroCard := NitroCard new.
 
 	cardsDistribution := Distribution with:
-		                     { (ProbabilityAssigner with: aNitroCard and: 1) }.
+		                     { (ProbabilityElement with: aNitroCard and: 1) }.
 
 	cardsCollection := cardsDistribution randomCollectionWith: 5.
 
@@ -360,7 +360,7 @@ FourthVersionTest >> testFV06WhenSpaceshipUsesNitroCardItAlsoLastsForThreeTurns 
 	aNitroCard := NitroCard new.
 
 	cardsDistribution := Distribution with:
-		                     { (ProbabilityAssigner with: aNitroCard and: 1) }.
+		                     { (ProbabilityElement with: aNitroCard and: 1) }.
 
 	cardsCollection := cardsDistribution randomCollectionWith: 5.
 
@@ -447,7 +447,7 @@ FourthVersionTest >> testFV07WhenSpaceshipUsesLeakCardItDuplicatesTheConsumption
 	aLeakCard := LeakCard new.
 
 	cardsDistribution := Distribution with:
-		                     { (ProbabilityAssigner with: aLeakCard and: 1) }.
+		                     { (ProbabilityElement with: aLeakCard and: 1) }.
 
 	cardsCollection := cardsDistribution randomCollectionWith: 5.
 
@@ -520,7 +520,7 @@ FourthVersionTest >> testFV08LeakCardIsCancelledWhenSpaceshipRunsOutOfFuel [
 	aLeakCard := LeakCard new.
 
 	cardsDistribution := Distribution with:
-		                     { (ProbabilityAssigner with: aLeakCard and: 1) }.
+		                     { (ProbabilityElement with: aLeakCard and: 1) }.
 
 	cardsCollection := cardsDistribution randomCollectionWith: 5.
 
@@ -720,7 +720,7 @@ FourthVersionTest >> testFV10WhenDeckIsEmptyAndDiscardDeckIsEmptyNoCardsCanBeTak
 	anAllyCard := AllyCard new.
 
 	cardsDistribution := Distribution with:
-		                     { (ProbabilityAssigner with: anAllyCard and: 1) }.
+		                     { (ProbabilityElement with: anAllyCard and: 1) }.
 
 	cardsCollection := cardsDistribution randomCollectionWith: 4.
 
@@ -770,7 +770,7 @@ FourthVersionTest >> testFV11WhenDiscardDeckIsEmptyAndACardFromDeckIsUsedBothEnd
 	aNitroCard := NitroCard new.
 
 	cardsDistribution := Distribution with:
-		                     { (ProbabilityAssigner with: aNitroCard and: 1) }.
+		                     { (ProbabilityElement with: aNitroCard and: 1) }.
 
 	cardsCollection := cardsDistribution randomCollectionWith: 4.
 


### PR DESCRIPTION
…clarative. Changed the name of Probability Assigner to ProbabilityElement to be coherent with this name used in other parts of the model